### PR TITLE
Add support for changelog in mod asset

### DIFF
--- a/Editor/ModEditor.cs
+++ b/Editor/ModEditor.cs
@@ -20,6 +20,7 @@ namespace REPOLibSdk.Editor
             Util.PropertyField("_websiteUrl", serializedObject, root);
             Util.PropertyField("_icon", serializedObject, root);
             Util.PropertyField("_readme", serializedObject, root);
+            Util.PropertyField("_changelog", serializedObject, root);
 
             var button = new Button(() => {
                 ExportWindow.Open((Mod)target);

--- a/Editor/PackageExporter.cs
+++ b/Editor/PackageExporter.cs
@@ -50,6 +50,7 @@ namespace REPOLibSdk.Editor
             File.Copy(bundlePath, finalBundlePath);
 
             WriteReadme(mod, packagePath);
+            WriteChangelog(mod, packagePath);
             WriteIcon(mod, packagePath);
             WriteManifest(mod, packagePath);
 
@@ -66,6 +67,13 @@ namespace REPOLibSdk.Editor
             File.Copy(fromPath, Path.Combine(packagePath, "README.md"));
         }
         
+
+        private static void WriteChangelog(Mod mod, string packagePath)
+        {
+            string fromPath = AssetDatabase.GetAssetPath(mod.Changelog);
+            File.Copy(fromPath, Path.Combine(packagePath, "CHANGELOG.md"));
+        }
+
         private static void WriteIcon(Mod mod, string packagePath)
         {
             string fromPath = AssetDatabase.GetAssetPath(mod.Icon);

--- a/Editor/PackageExporter.cs
+++ b/Editor/PackageExporter.cs
@@ -63,20 +63,50 @@ namespace REPOLibSdk.Editor
         
         private static void WriteReadme(Mod mod, string packagePath)
         {
+            if (mod.Readme == null)
+            {
+                Debug.LogWarning($"No Readme set for mod \"{mod.Name}\"");
+                return;
+            }
             string fromPath = AssetDatabase.GetAssetPath(mod.Readme);
+            if (string.IsNullOrWhiteSpace(fromPath) || !File.Exists(fromPath))
+            {
+                Debug.LogError($"Invalid readme path \"{fromPath}\".");
+                return;
+            }
             File.Copy(fromPath, Path.Combine(packagePath, "README.md"));
         }
         
 
         private static void WriteChangelog(Mod mod, string packagePath)
         {
+            if (mod.Changelog == null)
+            {
+                // Changelog isn't strictly necessary, no need to log a warning
+                return;
+            }
             string fromPath = AssetDatabase.GetAssetPath(mod.Changelog);
+            if (string.IsNullOrWhiteSpace(fromPath) || !File.Exists(fromPath))
+            {
+                Debug.LogError($"Invalid changelog path \"{fromPath}\".");
+                return;
+            }
             File.Copy(fromPath, Path.Combine(packagePath, "CHANGELOG.md"));
         }
 
         private static void WriteIcon(Mod mod, string packagePath)
         {
+            if (mod.Icon == null)
+            {
+                Debug.LogWarning($"No Icon set for mod \"{mod.Name}\"");
+                return;
+            }
             string fromPath = AssetDatabase.GetAssetPath(mod.Icon);
+            if (string.IsNullOrWhiteSpace(fromPath) || !File.Exists(fromPath))
+            {
+                Debug.LogError($"Invalid icon path \"{fromPath}\".");
+                return;
+            }
             File.Copy(fromPath, Path.Combine(packagePath, "icon.png"));
         }
         


### PR DESCRIPTION
Added fields to the mod viewer for changelog and function in `PackageExporter` for including it in the package. 

Also added some simple safety checks for if the paths referenced by the mod asset are invalid or unset, necessary since the changelog is not strictly required and should not log an error if it is omitted. 

See corresponding PR on the main repo: https://github.com/ZehsTeam/REPOLib/pull/9