### PR TITLE
Add RemoveNullValuablesPatch

### DIFF
--- a/BepInEx.meta
+++ b/BepInEx.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: fa38287cf1674cd6b769e10063369806
+timeCreated: 1742042639

--- a/BepInEx/REPOLib-Sdk.BepInEx.asmdef
+++ b/BepInEx/REPOLib-Sdk.BepInEx.asmdef
@@ -1,0 +1,19 @@
+{
+    "name": "REPOLib-Sdk.BepInEx",
+    "rootNamespace": "",
+    "references": [
+        "GUID:01fa4898ed3ed7141a89671b1a970967",
+        "GUID:8ea34b3f918d0a14fbc5c4ee2d5cc887"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/BepInEx/REPOLib-Sdk.BepInEx.asmdef.meta
+++ b/BepInEx/REPOLib-Sdk.BepInEx.asmdef.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d2b75ab561224a1cb379a00281fc6404
+timeCreated: 1742042642

--- a/BepInEx/RemoveNullValuablesPatch.cs
+++ b/BepInEx/RemoveNullValuablesPatch.cs
@@ -1,0 +1,55 @@
+﻿using HarmonyLib;
+using Nomnom.BepInEx.Editor;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace REPOLibSdk.BepInEx 
+{
+    [InjectPatch]
+    internal sealed class RemoveNullValuablesPatch
+    {
+        private static readonly Type _runManagerType = AccessTools.TypeByName("RunManager");
+        private static readonly Type _levelType = AccessTools.TypeByName("Level");
+        private static readonly Type _levelValuablesType = AccessTools.TypeByName("LevelValuables");
+
+        private static readonly string[] _levelValuablesFields = 
+        {
+            "tiny",
+            "small",
+            "medium",
+            "big",
+            "wide",
+            "tall",
+            "veryTall"
+        };
+        
+        public static MethodBase TargetMethod()
+        {
+            return AccessTools.Method(_runManagerType, "Awake");
+        }
+
+        public static void Prefix(MonoBehaviour __instance)
+        {
+            Debug.Log("Removing missing objects from valuable presets");
+            
+            IEnumerable<object> levels = (IEnumerable<object>)AccessTools.Field(_runManagerType, "levels").GetValue(__instance);
+
+            foreach (object level in levels)
+            {
+                IEnumerable<object> presets = (IEnumerable<object>)AccessTools.Field(_levelType, "ValuablePresets").GetValue(level);
+
+                foreach (object preset in presets)
+                {
+                    foreach (string fieldName in _levelValuablesFields)
+                    {
+                        List<GameObject> valuables = (List<GameObject>)AccessTools.Field(_levelValuablesType, fieldName).GetValue(preset);
+                        valuables.RemoveAll(obj => obj == null);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/BepInEx/RemoveNullValuablesPatch.cs.meta
+++ b/BepInEx/RemoveNullValuablesPatch.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d4b435b72bc744bb9ec18daabeba9b91
+timeCreated: 1742042745


### PR DESCRIPTION
When playing in the editor, the `LevelValuables` objects aren't reset between plays. This causes the runtime-added custom valuables to become missing.