### PR TITLE
Invalid mod name warning and better docs

### DIFF
--- a/Editor/ModEditor.cs
+++ b/Editor/ModEditor.cs
@@ -1,4 +1,6 @@
 ﻿using REPOLib.Objects.Sdk;
+using System.Linq;
+using System.Text.RegularExpressions;
 using UnityEditor;
 using UnityEditor.UIElements;
 using UnityEngine.UIElements;
@@ -14,7 +16,27 @@ namespace REPOLibSdk.Editor
             
             var root = new VisualElement();
 
-            Util.PropertyField("_name", serializedObject, root);
+            var nameField = new TextField
+            {
+                label = "Name",
+                bindingPath = "_name"
+            };
+            
+            root.Add(nameField);
+            
+            var helpBox = new HelpBox
+            {
+                messageType = HelpBoxMessageType.Error
+            };
+            string modName = serializedObject.FindProperty("_name").stringValue;
+            UpdateHelpBoxState(modName, helpBox);
+            nameField.RegisterValueChangedCallback(evt =>
+            {
+                UpdateHelpBoxState(evt.newValue, helpBox);
+            });
+            
+            root.Add(helpBox);
+            
             Util.PropertyField("_author", serializedObject, root);
             Util.PropertyField("_version", serializedObject, root);
             Util.PropertyField("_description", serializedObject, root);
@@ -37,6 +59,33 @@ namespace REPOLibSdk.Editor
             root.Add(button);
 
             return root;
+        }
+
+        private static void UpdateHelpBoxState(string name, HelpBox box)
+        {
+            string error = GetError(name);
+            if (string.IsNullOrEmpty(error))
+            {
+                box.SetVisible(false);
+            }
+            else
+            {
+                box.text = error;
+                box.SetVisible(true);
+            }
+            
+            return;
+
+            string GetError(string modName)
+            {
+                if (modName.Contains(" ")) return "Name cannot contain spaces!";
+                if (modName.Contains("-")) return "Name cannot contain hyphens!";
+                if (modName.Contains(".")) return "Name cannot contain periods!";
+                if (modName.Length == 0) return "Name cannot be empty!";
+                if (!Regex.IsMatch(modName, "^[a-zA-Z0-9_]+$")) return "Name contains invalid characters!";
+
+                return null;
+            }
         }
     }
 }

--- a/Editor/ModExportSettingsSource.cs
+++ b/Editor/ModExportSettingsSource.cs
@@ -38,6 +38,13 @@ namespace REPOLibSdk.Editor
             for (int i = 0; i < _settings.Count; i++)
             {
                 var settings = _settings[i];
+                if (settings == null)
+                {
+                    _settings.RemoveAt(i);
+                    i--;
+                    continue;
+                }
+                
                 if (settings.Mod != null) continue;
                 
                 AssetDatabase.RemoveObjectFromAsset(settings);

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If not, use a tool like [R.E.P.O. Project Patcher](https://github.com/Kesomannen
 - Fill in the fields:
   - `Prefab`: A reference to your prefab. The prefab does not have to be in the mod folder.
   - `Valuable Presets`: The valuable presets to register the valuable to. The vanilla values are:
-    - `Valuables - Generic`
+    - `Valuables - Generic` (applies to every level)
     - `Valuables - Wizard`
     - `Valuables - Manor`
     - `Valuables - Arctic`
@@ -84,11 +84,33 @@ If not, use a tool like [R.E.P.O. Project Patcher](https://github.com/Kesomannen
 
 - Select the `Mod` asset and click `Export` in the inspector.
   - In the window you'll see the associated content files found by REPOLib-Sdk.
-- Choose an `Output Path`. If there isn't a folder at the selected path, one will be created.
-- Click `Export` and wait. Once finished, a window should appear showing the exported zip file. This file can be uploaded to Thunderstore or locally imported into mod managers.
 
 > [!TIP]
 > The export window can also be accessed from `Window > REPOLib Exporter`
+
+- Choose an `Output Path`. The path is relative to the Unity project (unless you specify an absolute path).
+
+> [!WARNING]
+> REPOLib-Sdk deletes and creates multiple folders and files under the export path. Therefore, it is recommended to use a new, empty folder as the target.
+
+- Click `Export` and wait. Once finished, a window should appear showing the exported zip file. This file can be uploaded to Thunderstore or locally imported into mod managers.
+
+### Using custom scripts
+
+Unfortunately, custom scripts cannot be developed from inside the Unity editor. Instead, you have to write your scripts elsewhere:
+
+- Create a new C# project for R.E.P.O. modding.
+  - There are templates available for this, for example [linkoid's Repo Sdks](https://github.com/linkoid/Repo.Sdks) and [Matty's Mod Templates](https://discord.com/channels/1344557689979670578/1348716513410027601) (discord thread link).
+- Write your scripts in that project.
+- Build the project and copy the output dll into your Unity project.
+
+> [!TIP]
+> You can use a MSBuild target to automatically copy the dll on each build.
+
+- If needed, copy the BepInEx dlls to your project.
+  - If you used the [R.E.P.O. Project Patcher](https://github.com/Kesomannen/unity-repo-project-patcher), these will already be in your project.
+- Attach the scripts to your prefabs.
+- Include the dll in the `Extra Files` field on your `Mod` asset.
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -84,16 +84,14 @@ If not, use a tool like [R.E.P.O. Project Patcher](https://github.com/Kesomannen
 
 - Select the `Mod` asset and click `Export` in the inspector.
   - In the window you'll see the associated content files found by REPOLib-Sdk.
-
-> [!TIP]
-> The export window can also be accessed from `Window > REPOLib Exporter`
-
 - Choose an `Output Path`. The path is relative to the Unity project (unless you specify an absolute path).
+- Click `Export` and wait. Once finished, a window should appear showing the exported zip file. This file can be uploaded to Thunderstore or locally imported into mod managers.
 
 > [!WARNING]
 > REPOLib-Sdk deletes and creates multiple folders and files under the export path. Therefore, it is recommended to use a new, empty folder as the target.
 
-- Click `Export` and wait. Once finished, a window should appear showing the exported zip file. This file can be uploaded to Thunderstore or locally imported into mod managers.
+> [!TIP]
+> The export window can also be accessed from `Window > REPOLib Exporter`
 
 ### Using custom scripts
 
@@ -103,14 +101,13 @@ Unfortunately, custom scripts cannot be developed from inside the Unity editor. 
   - There are templates available for this, for example [linkoid's Repo Sdks](https://github.com/linkoid/Repo.Sdks) and [Matty's Mod Templates](https://discord.com/channels/1344557689979670578/1348716513410027601) (discord thread link).
 - Write your scripts in that project.
 - Build the project and copy the output dll into your Unity project.
-
-> [!TIP]
-> You can use a MSBuild target to automatically copy the dll on each build.
-
 - If needed, copy the BepInEx dlls to your project.
   - If you used the [R.E.P.O. Project Patcher](https://github.com/Kesomannen/unity-repo-project-patcher), these will already be in your project.
 - Attach the scripts to your prefabs.
 - Include the dll in the `Extra Files` field on your `Mod` asset.
+
+> [!TIP]
+> You can use a MSBuild target to automatically copy the dll on each build.
 
 ## Contribute
 

--- a/Scripts/RoomVolumeCheckEditor.cs.meta
+++ b/Scripts/RoomVolumeCheckEditor.cs.meta
@@ -1,3 +1,3 @@
 ﻿fileFormatVersion: 2
-guid: 4a68b88d543240bbaaf6e0d6627bb916
+guid: 4534051a3286d3044930e419b1848465
 timeCreated: 1741590590


### PR DESCRIPTION
Added a warning on the `Mod` editor if the name is invalid on Thunderstore.

Also added clarifications and a section on custom scripts to the readme.